### PR TITLE
Update addon-developer-support

### DIFF
--- a/src/api/WindowListener/implementation.js
+++ b/src/api/WindowListener/implementation.js
@@ -2,7 +2,7 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
- * Version: 1.60
+ * Version 1.62
  *
  * Author: John Bieling (john@thunderbird.net)
  *
@@ -18,7 +18,8 @@ var { ExtensionCommon } = ChromeUtils.import(
 var { ExtensionSupport } = ChromeUtils.import(
   "resource:///modules/ExtensionSupport.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
 function getThunderbirdVersion() {
   let parts = Services.appinfo.version.split(".");
@@ -402,9 +403,8 @@ var WindowListener_102 = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           let prefsObj = {};
-          prefsObj.Services = ChromeUtils.import(
-            "resource://gre/modules/Services.jsm"
-          ).Services;
+          prefsObj.Services = globalThis.Services||
+            ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
           prefsObj.pref = function (aName, aDefault) {
             let defaults = Services.prefs.getDefaultBranch("");
             switch (typeof aDefault) {
@@ -1476,9 +1476,8 @@ var WindowListener_115 = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           let prefsObj = {};
-          prefsObj.Services = ChromeUtils.import(
-            "resource://gre/modules/Services.jsm"
-          ).Services;
+          prefsObj.Services = globalThis.Services||
+            ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
           prefsObj.pref = function (aName, aDefault) {
             let defaults = Services.prefs.getDefaultBranch("");
             switch (typeof aDefault) {
@@ -1678,8 +1677,8 @@ var WindowListener_115 = class extends ExtensionCommon.ExtensionAPI {
 
   async _loadIntoWindow(window, isAddonActivation) {
     const fullyLoaded = async window => {
-      for (let i = 0; i < 10; i++) {
-        await this.sleep(100);
+      for (let i = 0; i < 20; i++) {
+        await this.sleep(50);
         if (
           window &&
           window.location.href != "about:blank" &&
@@ -1688,9 +1687,15 @@ var WindowListener_115 = class extends ExtensionCommon.ExtensionAPI {
           return;
         }
       }
+      throw new Error("Window ignored");
     }
 
-    await fullyLoaded(window);
+    try {
+      await fullyLoaded(window);
+    } catch(ex) {
+      return;
+    }
+
     if (!window || window.hasOwnProperty(this.uniqueRandomID)) {
       return;
     }


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . The latest addon-developer-support source reflects the change.