### PR TITLE
Fix setting original folders in Thunderbird 115

### DIFF
--- a/src/chrome/content/removedupes.js
+++ b/src/chrome/content/removedupes.js
@@ -808,7 +808,7 @@ RemoveDupes.MessengerOverlay.setOriginalsFolders = function () {
     let selectedMsgFolders = GetSelectedMsgFolders();
     RemoveDupes.MessengerOverlay.originalsFolders = new Set();
     RemoveDupes.MessengerOverlay.originalsFolderUris = new Set();
-    for (let originalsFolder of RemoveDupes.MessengerOverlay.originalsFolders) {
+    for (let originalsFolder of selectedMsgFolders) {
       RemoveDupes.MessengerOverlay.originalsFolders.add(originalsFolder);
       RemoveDupes.MessengerOverlay.originalsFolderUris.add(originalsFolder.URI);
     }


### PR DESCRIPTION
This commit fixes a small typo that caused `originalsFolders` and `originalsFolderUris` to always be set to an empty set.