### PR TITLE
Restore removedupes items in rebuilt folder context menus

### DIFF
--- a/src/chrome/content/overlay-injectors/3pane.js
+++ b/src/chrome/content/overlay-injectors/3pane.js
@@ -1,5 +1,5 @@
 function injectOtherElements() {
-   WL.injectElements(
+  WL.injectElements(
     `
     <popup id="folderPaneContext">
       <menuitem id="removeDuplicatesContextMenuItemsRemove"
@@ -20,10 +20,38 @@ function injectOtherElements() {
     ],
     false // debugInjection
   );
-  WL.injectCSS("chrome://removedupes/content/skin/classic/removedupes-messenger.css");
+}
+
+const folderContextItemIds = [
+  "removeDuplicatesContextMenuItemsRemove",
+  "removeDuplicatesContextMenuItemsSetOriginals",
+  "folderPaneContext-removedupes-separator",
+];
+
+function removeInjectedFolderContextItems() {
+  for (const id of folderContextItemIds) {
+    let item = document.getElementById(id);
+    while (item) {
+      item.remove();
+      item = document.getElementById(id);
+    }
+  }
+}
+
+function onFolderPaneContextShowing(event) {
+  if (event.target.id === "folderPaneContext") {
+    removeInjectedFolderContextItems();
+    injectOtherElements();
+  }
 }
 
 // called on window load or on add-on activation while window is already open
 function onLoad(activatedWhileWindowOpen) {
   injectOtherElements();
+  WL.injectCSS("chrome://removedupes/content/skin/classic/removedupes-messenger.css");
+  window.addEventListener("popupshowing", onFolderPaneContextShowing);
+}
+
+function onUnload(deactivatedWhileWindowOpen) {
+  window.removeEventListener("popupshowing", onFolderPaneContextShowing);
 }

--- a/test/3pane-context-menu.test.js
+++ b/test/3pane-context-menu.test.js
@@ -1,0 +1,62 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const contextMenuItemIds = [
+  "removeDuplicatesContextMenuItemsRemove",
+  "removeDuplicatesContextMenuItemsSetOriginals",
+  "folderPaneContext-removedupes-separator",
+];
+
+test("restores folder context menu items after Thunderbird rebuilds the menu", () => {
+  const menuItems = [];
+  const listeners = new Map();
+  const document = {
+    getElementById(id) {
+      const item = menuItems.find((candidate) => candidate.id === id);
+      if (!item) {
+        return null;
+      }
+      return {
+        remove() {
+          menuItems.splice(menuItems.indexOf(item), 1);
+        },
+      };
+    },
+  };
+  const window = {
+    addEventListener(type, listener) {
+      listeners.set(type, listener);
+    },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) {
+        listeners.delete(type);
+      }
+    },
+    dispatchEvent(event) {
+      listeners.get(event.type)?.(event);
+    },
+  };
+  const WL = {
+    injectCSS() {},
+    injectElements() {
+      contextMenuItemIds.forEach((id) => menuItems.push({ id }));
+    },
+  };
+  const context = vm.createContext({ document, WL, window });
+  const injectorPath = path.join(__dirname, "../src/chrome/content/overlay-injectors/3pane.js");
+
+  vm.runInContext(fs.readFileSync(injectorPath, "utf8"), context);
+  context.onLoad(false);
+  menuItems.length = 0;
+  window.dispatchEvent({ type: "popupshowing", target: { id: "folderPaneContext" } });
+  window.dispatchEvent({ type: "popupshowing", target: { id: "folderPaneContext" } });
+
+  assert.deepEqual(
+    menuItems.map(({ id }) => id),
+    contextMenuItemIds,
+    "folder context commands should be restored exactly once when the menu opens"
+  );
+});


### PR DESCRIPTION
## Summary
- re-inject removedupes commands when the about:3pane folder context menu opens
- remove surviving removedupes nodes first so repeated popup events cannot duplicate commands
- remove the popup listener when the overlay unloads
- add a focused regression test covering menu rebuilds and repeated openings

## Tests
- `OPENSSL_CONF=/dev/null node test/3pane-context-menu.test.js`
- `OPENSSL_CONF=/dev/null node --check src/chrome/content/overlay-injectors/3pane.js`
- `OPENSSL_CONF=/dev/null node --check test/3pane-context-menu.test.js`

`npm run lint` could not complete because the installed dependency cache was missing `@eslint/eslintrc`. Manual Thunderbird verification was not performed.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1018:start -->
### Verification

[Northset proof-of-pass receipt M-1018](https://northset-oss.github.io/verification-pilot/receipts/M-1018/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1018:end -->
