### PR TITLE
Add toolbar button for Thunderbird 128+

### DIFF
--- a/dobuild
+++ b/dobuild
@@ -124,6 +124,10 @@ mkdir -p $BUILD_DIR/api/WindowListener
 cp src/api/WindowListener/schema.json $BUILD_DIR/api/WindowListener
 cp src/api/WindowListener/implementation.js $BUILD_DIR/api/WindowListener
 
+mkdir -p $BUILD_DIR/api/NotifyTools
+cp src/api/NotifyTools/schema.json $BUILD_DIR/api/NotifyTools
+cp src/api/NotifyTools/implementation.js $BUILD_DIR/api/NotifyTools
+
 cd $BUILD_DIR
 zip --quiet -r $XPI_NAME  \
 	chrome \

--- a/src/api/NotifyTools/README.md
+++ b/src/api/NotifyTools/README.md
@@ -1,0 +1,151 @@
+# Objective
+
+The NotifyTools provide a bidirectional messaging system between Experiments scripts and the WebExtension's background page (even with [e10s](https://developer.thunderbird.net/add-ons/updating/tb91/changes#thunderbird-is-now-multi-process-e-10-s) being enabled in Thunderbird Beta 86).
+
+![messaging](https://user-images.githubusercontent.com/5830621/111921572-90db8d80-8a95-11eb-8673-4e1370d49e4b.png)
+
+They allow to work on add-on uprades in smaller steps, as single calls (like `window.openDialog()`)
+in the middle of legacy code can be replaced by WebExtension calls, by stepping out of the Experiment
+and back in when the task has been finished.
+
+More details can be found in [this update tutorial](https://github.com/thundernest/addon-developer-support/wiki/Tutorial:-Convert-add-on-parts-individually-by-using-a-messaging-system).
+
+# Example
+
+This repository includes the [NotifyToolsExample Add-On](https://github.com/thundernest/addon-developer-support/raw/master/auxiliary-apis/NotifyTools/notifyToolsExample.zip), showcasing how the NotifyTools can be used.
+
+# Usage
+
+Add the [NotifyTools API](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/NotifyTools) to your add-on. Your `manifest.json` needs an entry like this:
+
+```
+  "experiment_apis": {
+    "NotifyTools": {
+      "schema": "api/NotifyTools/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["NotifyTools"]],
+        "script": "api/NotifyTools/implementation.js",
+        "events": ["startup"]
+      }
+    }
+  },
+```
+
+Additionally to the [NotifyTools API](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/NotifyTools) the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script is needed as the counterpart in Experiment scripts.
+
+**Note:** You need to adjust the `notifyTools.js` script and add your add-on ID at the top.
+
+## Receiving notifications from Experiment scripts
+
+Add a listener for the `onNotifyBackground` event in your WebExtension's background page:
+
+```
+messenger.NotifyTools.onNotifyBackground.addListener(async (info) => {
+  switch (info.command) {
+    case "doSomething":
+      //do something
+      let rv = await doSomething();
+      return rv;
+      break;
+  }
+});
+```
+
+The `onNotifyBackground` event will receive and respond to notifications send from your Experiment scripts:
+
+```
+notifyTools.notifyBackground({command: "doSomething"}).then((data) => {
+  console.log(data);
+});
+```
+
+Include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script in your Experiment script to be able to use `notifyTools.notifyBackground()`. If you are injecting the script into a global Thunderbird window object, make sure to wrap it in your custom namespace, to prevent clashes with other add-ons.
+
+**Note**: If multiple `onNotifyBackground` listeners are registered in the WebExtension's background page and more than one is returning data, the value
+from the first one is returned to the Experiment. This may lead to inconsistent behavior, so make sure that for each
+request only one listener is returning data.
+
+
+## Sending notifications to Experiments scripts
+
+Use the `notifyExperiment()` method to send a notification from the WebExtension's background page to Experiment scripts:
+
+```
+messenger.NotifyTools.notifyExperiment({command: "doSomething"}).then((data) => {
+  console.log(data)
+});
+```
+
+The receiving Experiment script needs to include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script  and must setup a listener using the following methods:
+
+### addListener(callback);
+
+Adds a callback function, which is called when a notification from the WebExtension's background page has been received. The `addListener()` function returns an `id` which can be used to remove the listener again.
+
+Example:
+
+```
+function doSomething(data) {
+  console.log(data);
+  return true;
+}
+let id = notifyTools.addListener(doSomething);
+```
+
+**Note**: NotifyTools currently is not 100% compatible with the behavior of
+runtime.sendMessage. While runtime messaging is ignoring non-Promise return
+values, NotifyTools only ignores `null`.
+
+Why does this matter? Consider the following three listeners:
+ 
+```
+async function dominant_listener(data) {
+ if (data.type == "A") {
+   return { msg: "I should answer only type A" };
+ }
+}
+ 
+function silent_listener(data) {
+ if (data.type == "B") {
+   return { msg: "I should answer only type B" };
+ }
+}
+
+function selective_listener(data) {
+ if (data.type == "C") {
+   return Promise.resolve({ msg: "I should answer only type C" });
+ }
+}
+```
+ 
+When all 3 listeners are registered for the runtime.onMessage event,
+the dominant listener will always respond, even for `data.type != "A"` requests,
+because it is always returning a Promise (it is an async function). The return
+value of the silent listener is ignored, and the selective listener returns a
+value just for `data.type == "C"`. But since the dominant listener also returns
+`null` for these requests, the actual return value depends on which listener is faster
+and/or was registered first.
+ 
+All notifyTools listener however ignore only `null` return values (so `null` can
+actually never be returned). The above dominant listener will only respond to 
+`type == "A"` requests, the silent listener will only respond to `type == "B"` 
+requests and the selective listener will respond only to `type == "C"` requests.
+
+### removeListener(id)
+
+Removes the listener with the given `id`.
+
+Example:
+
+```
+notifyTools.removeListener(id);
+```
+
+### removeAllListeners()
+
+You must remove all added listeners when your add-on is disabled/reloaded. Instead of calling `removeListener()` for each added listener, you may call `removeAllListeners()`.
+
+### setAddOnId(add-on-id)
+
+The `notifyTools.js` script needs to know the ID of your add-on to be able to listen for messages. You may either define the ID directly in the first line of the script, or set it using `setAddOnId()`.

--- a/src/api/NotifyTools/implementation.js
+++ b/src/api/NotifyTools/implementation.js
@@ -1,0 +1,142 @@
+/*
+ * This file is provided by the addon-developer-support repository at
+ * https://github.com/thundernest/addon-developer-support
+ *
+ * Version 1.5
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
+ *
+ * Version 1.4
+ *  - updated implementation to not assign this anymore
+ * 
+ * Version 1.3
+ *  - moved registering the observer into startup
+ *
+ * Version 1.1
+ *  - added startup event, to make sure API is ready as soon as the add-on is starting
+ *    NOTE: This requires to add the startup event to the manifest, see:
+ *    https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/NotifyTools#usage
+ *
+ * Author: John Bieling (john@thunderbird.net)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+"use strict";
+
+(function (exports) {
+
+  // Get various parts of the WebExtension framework that we need.
+  var { ExtensionCommon } = ChromeUtils.importESModule(
+    "resource://gre/modules/ExtensionCommon.sys.mjs"
+  );
+
+  var Services = globalThis.Services || 
+    ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+
+  var observerTracker = new Set();
+
+  class NotifyTools extends ExtensionCommon.ExtensionAPI {
+    getAPI(context) {
+      return {
+        NotifyTools: {
+
+          notifyExperiment(data) {
+            return new Promise(resolve => {
+              Services.obs.notifyObservers(
+                { data, resolve },
+                "NotifyExperimentObserver",
+                context.extension.id
+              );
+            });
+          },
+
+          onNotifyBackground: new ExtensionCommon.EventManager({
+            context,
+            name: "NotifyTools.onNotifyBackground",
+            register: (fire) => {
+              observerTracker.add(fire.sync);
+              return () => {
+                observerTracker.delete(fire.sync);
+              };
+            },
+          }).api(),
+
+        }
+      };
+    }
+
+    // Force API to run at startup, otherwise event listeners might not be added at the requested time. Also needs
+    // "events": ["startup"] in the experiment manifest
+    onStartup() {
+      this.onNotifyBackgroundObserver = async (aSubject, aTopic, aData) => {
+        if (
+          observerTracker.size > 0 &&
+          aData == this.extension.id
+        ) {
+          let payload = aSubject.wrappedJSObject;
+
+          // Make sure payload has a resolve function, which we use to resolve the
+          // observer notification.
+          if (payload.resolve) {
+            let observerTrackerPromises = [];
+            // Push listener into promise array, so they can run in parallel
+            for (let listener of observerTracker.values()) {
+              observerTrackerPromises.push(listener(payload.data));
+            }
+            // We still have to await all of them but wait time is just the time needed
+            // for the slowest one.
+            let results = [];
+            for (let observerTrackerPromise of observerTrackerPromises) {
+              let rv = await observerTrackerPromise;
+              if (rv != null) results.push(rv);
+            }
+            if (results.length == 0) {
+              payload.resolve();
+            } else {
+              if (results.length > 1) {
+                console.warn(
+                  "Received multiple results from onNotifyBackground listeners. Using the first one, which can lead to inconsistent behavior.",
+                  results
+                );
+              }
+              payload.resolve(results[0]);
+            }
+          } else {
+            // Older version of NotifyTools, which is not sending a resolve function, deprecated.
+            console.log("Please update the notifyTools API and the notifyTools script to at least v1.5");
+            for (let listener of observerTracker.values()) {
+              listener(payload.data);
+            }
+          }
+        }
+      };
+
+      // Add observer for notifyTools.js
+      Services.obs.addObserver(
+        this.onNotifyBackgroundObserver,
+        "NotifyBackgroundObserver",
+        false
+      );
+    }
+
+    onShutdown(isAppShutdown) {
+      if (isAppShutdown) {
+        return; // the application gets unloaded anyway
+      }
+
+      // Remove observer for notifyTools.js
+      Services.obs.removeObserver(
+        this.onNotifyBackgroundObserver,
+        "NotifyBackgroundObserver"
+      );
+
+      // Flush all caches
+      Services.obs.notifyObservers(null, "startupcache-invalidate");
+    }
+  };
+
+  exports.NotifyTools = NotifyTools;
+
+})(this)

--- a/src/api/NotifyTools/schema.json
+++ b/src/api/NotifyTools/schema.json
@@ -1,0 +1,34 @@
+[
+  {
+    "namespace": "NotifyTools",    
+    "events": [
+      {
+        "name": "onNotifyBackground",
+        "type": "function",
+        "description": "Fired when a new notification from notifyTools.js in an Experiment has been received.",
+        "parameters": [
+          {
+            "name": "data",
+            "type": "any",
+            "description": "Restrictions of the structured clone algorithm apply."
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "notifyExperiment",
+        "type": "function",
+        "async": true,
+        "description": "Notifies notifyTools.js in an Experiment and sends data.",
+        "parameters": [
+          {
+            "name": "data",
+            "type": "any",
+            "description": "Restrictions of the structured clone algorithm apply."
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/background.js
+++ b/src/background.js
@@ -66,4 +66,13 @@ function registerChromeInjectors(chromeInjectors) {
   registerDefaultPrefs();
   registerOptionsPage();
   messenger.WindowListener.startListening();
+
+  // Toolbar button triggers duplicate search via NotifyTools
+  browser.browserAction.onClicked.addListener((tab) => {
+    messenger.NotifyTools.notifyExperiment({
+      event: "searchAndRemoveDuplicateMessages",
+      tabId: tab?.id
+    });
+  });
+
 })();

--- a/src/chrome/content/notifyTools.js
+++ b/src/chrome/content/notifyTools.js
@@ -1,0 +1,168 @@
+// Set this to the ID of your add-on, or call notifyTools.setAddonID().
+var ADDON_ID = "{a300a000-5e21-4ee0-a115-9ec8f4eaa92b}";
+
+/*
+ * This file is provided by the addon-developer-support repository at
+ * https://github.com/thundernest/addon-developer-support
+ *
+ * For usage descriptions, please check:
+ * https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools
+ *
+ * Version 1.6
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
+ *
+ * Version 1.5
+ * - deprecate enable(), disable() and registerListener()
+ * - add setAddOnId()
+ *
+ * Version 1.4
+ * - auto enable/disable
+ *
+ * Version 1.3
+ * - registered listeners for notifyExperiment can return a value
+ * - remove WindowListener from name of observer
+ *
+ * Author: John Bieling (john@thunderbird.net)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+
+var notifyTools = {
+  registeredCallbacks: {},
+  registeredCallbacksNextId: 1,
+  addOnId: ADDON_ID,
+
+  setAddOnId: function (addOnId) {
+    this.addOnId = addOnId;
+  },
+
+  onNotifyExperimentObserver: {
+    observe: async function (aSubject, aTopic, aData) {
+      if (notifyTools.addOnId == "") {
+        throw new Error("notifyTools: ADDON_ID is empty!");
+      }
+      if (aData != notifyTools.addOnId) {
+        return;
+      }
+      let payload = aSubject.wrappedJSObject;
+
+      // Make sure payload has a resolve function, which we use to resolve the
+      // observer notification.
+      if (payload.resolve) {
+        let observerTrackerPromises = [];
+        // Push listener into promise array, so they can run in parallel
+        for (let registeredCallback of Object.values(
+          notifyTools.registeredCallbacks
+        )) {
+          observerTrackerPromises.push(registeredCallback(payload.data));
+        }
+        // We still have to await all of them but wait time is just the time needed
+        // for the slowest one.
+        let results = [];
+        for (let observerTrackerPromise of observerTrackerPromises) {
+          let rv = await observerTrackerPromise;
+          if (rv != null) results.push(rv);
+        }
+        if (results.length == 0) {
+          payload.resolve();
+        } else {
+          if (results.length > 1) {
+            console.warn(
+              "Received multiple results from onNotifyExperiment listeners. Using the first one, which can lead to inconsistent behavior.",
+              results
+            );
+          }
+          payload.resolve(results[0]);
+        }
+      } else {
+        // Older version of NotifyTools, which is not sending a resolve function, deprecated.
+        console.log("Please update the notifyTools API to at least v1.5");
+        for (let registeredCallback of Object.values(
+          notifyTools.registeredCallbacks
+        )) {
+          registeredCallback(payload.data);
+        }
+      }
+    },
+  },
+
+  addListener: function (listener) {
+    if (Object.values(this.registeredCallbacks).length == 0) {
+      Services.obs.addObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver",
+        false
+      );
+    }
+
+    let id = this.registeredCallbacksNextId++;
+    this.registeredCallbacks[id] = listener;
+    return id;
+  },
+
+  removeListener: function (id) {
+    delete this.registeredCallbacks[id];
+    if (Object.values(this.registeredCallbacks).length == 0) {
+      Services.obs.removeObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver"
+      );
+    }
+  },
+
+  removeAllListeners: function () {
+    if (Object.values(this.registeredCallbacks).length != 0) {
+      Services.obs.removeObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver"
+      );
+    }
+    this.registeredCallbacks = {};
+  },
+
+  notifyBackground: function (data) {
+    if (this.addOnId == "") {
+      throw new Error("notifyTools: ADDON_ID is empty!");
+    }
+    return new Promise((resolve) => {
+      Services.obs.notifyObservers(
+        { data, resolve },
+        "NotifyBackgroundObserver",
+        this.addOnId
+      );
+    });
+  },
+
+
+  // Deprecated.
+
+  enable: function () {
+    console.log("Manually calling notifyTools.enable() is no longer needed.");
+  },
+
+  disable: function () {
+    console.log("notifyTools.disable() has been deprecated, use notifyTools.removeAllListeners() instead.");
+    this.removeAllListeners();
+  },
+
+  registerListener: function (listener) {
+    console.log("notifyTools.registerListener() has been deprecated, use notifyTools.addListener() instead.");
+    this.addListener(listener);
+  },
+
+};
+
+if (typeof window != "undefined" && window) {
+  window.addEventListener(
+    "unload",
+    function (event) {
+      notifyTools.removeAllListeners();
+    },
+    false
+  );
+}

--- a/src/chrome/content/overlay-injectors/3pane.js
+++ b/src/chrome/content/overlay-injectors/3pane.js
@@ -1,3 +1,4 @@
+var ADDON_ID = "{a300a000-5e21-4ee0-a115-9ec8f4eaa92b}";
 function injectOtherElements() {
    WL.injectElements(
     `
@@ -55,15 +56,70 @@ function onFolderPaneContextPopupShowing(event) {
   }
 }
 
+function isCurrentTab(tabId) {
+  if (!tabId) { return false;  }
+  try {
+    const { ExtensionParent } = ChromeUtils.importESModule(
+      "resource://gre/modules/ExtensionParent.sys.mjs"
+    );
+    const extension = ExtensionParent.GlobalManager.getExtension(ADDON_ID);
+    const tabMail = window?.top?.gTabmail;
+    if (!tabMail) {
+      console.warn("Could not determine current tabId: gTabmail is not available, top window:", window.top);
+      return false;
+    }
+    const tabInfo = tabMail.currentTabInfo;
+    const currentTabId = extension.tabManager.getWrapper(tabInfo).id;
+    return tabId === currentTabId;
+  } catch (ex) {
+    console.error("Could not determine current tabId", ex);
+    return false;
+  }
+}
+
+const DEBUG = false;
+function logDebug(...args) {
+  if (DEBUG) {
+    console.log("[REMOVE DUPLICATES]\n", ...args);
+  }
+}
+
+function onNotifyExperiment(data) {
+  logDebug("onNotifyExperiment", {this:this, data:data, win:window.location.href});
+  switch (data.event) {
+    case "searchAndRemoveDuplicateMessages":
+      if (!isCurrentTab(data?.tabId)) {
+        logDebug(`Ignoring notification for other tab: ${data?.tabId}`);
+        return;
+      }
+      window.top.RemoveDupes.MessengerOverlay.searchAndRemoveDuplicateMessages(null);
+      break;
+  }
+}
+
 function addEventListeners() {
   document
     .getElementById("folderPaneContext")
     .addEventListener("popupshowing", onFolderPaneContextPopupShowing);
+  logDebug("Adding listener for NotifyTools.onNotifyExperiment", this);
+  this.notifyListenerId = this.notifyTools.addListener(onNotifyExperiment);
 }
 
 // called on window load or on add-on activation while window is already open
 function onLoad(activatedWhileWindowOpen) {
   injectOtherElements();
+
+  var { ExtensionParent } = ChromeUtils.importESModule(
+    "resource://gre/modules/ExtensionParent.sys.mjs"
+  );
+  let ext = ExtensionParent.GlobalManager.getExtension(ADDON_ID);
+  Services.scriptloader.loadSubScript(
+    ext.rootURI.resolve("chrome/content/notifyTools.js"),
+    this,
+    "UTF-8"
+  );
+
+  this.notifyTools.setAddOnId(ADDON_ID);
   addEventListeners();
 }
 
@@ -71,4 +127,6 @@ function onUnload(activatedWhileWindowOpen) {
   document
     .getElementById("folderPaneContext")
     .removeEventListener("popupshowing", onFolderPaneContextPopupShowing);
+  logDebug("Removing listener for NotifyTools.onNotifyExperiment", this);
+  this.notifyTools.removeListener(this.notifyListenerId);
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,6 +35,22 @@
 				"paths": [["WindowListener"]],
 				"script": "api/WindowListener/implementation.js"
 			}
+    },
+    "NotifyTools": {
+      "schema": "api/NotifyTools/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["NotifyTools"]],
+        "script": "api/NotifyTools/implementation.js",
+        "events": ["startup"]
+      }
+    }
+  },
+  "browser_action": {
+    "default_title": "Remove Duplicate Messages",
+    "default_icon": {
+      "32": "chrome/content/removedupes.png",
+      "16": "chrome/content/removedupes-button-16x16.png"
 		}
 	},
 	"background": {


### PR DESCRIPTION
This PR restores the toolbar button functionality for Thunderbird 128+.

The toolbar button was already defined in the add-on description as a feature, but it stopped working after Thunderbird's UI changes made toolbar access more restricted.

Changes:
- Add a browser_action toolbar button using the existing Remove Dupes icons.
- Connect the button to the duplicate search command via NotifyTools.
- Pass the originating tab ID and ensure the command only executes in the active 3pane tab.
- Add proper NotifyTools listener cleanup on unload.

This brings back the quick access toolbar functionality mentioned in the ATN description.

References [[issue 1]](Tracking issue: https://github.com/RealRaven2000/remove-duplicates/issues/1)